### PR TITLE
v1.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="html2object",
-    version="0.1.4",
+    version="1.0.0",
     author="boterop",
     author_email="boterop22@gmail.com",
     description="Tools to handle the CRUD of .html files as objects.",


### PR DESCRIPTION
## 1.0.0 (15.05.2024)

- Renamed the `find_element_by_id` function to `get_element_by_id` for consistency with the `getElementById` function in JavaScript.
- Added a new function `get_elements_by_name(name: str) -> list[HtmlElement]` to retrieve all HTML element by its name.